### PR TITLE
Update temp.component.js to match Vue styleguide

### DIFF
--- a/lib/blueprints/component/temp.component.js
+++ b/lib/blueprints/component/temp.component.js
@@ -1,19 +1,19 @@
 export default  {
   name: '{{name | kebabCase}}',
+  components: {}, 
   props: [],
-  mounted() {
-    
-  },
-  data() {
+  data () {
     return {
-      
+
     }
-  },
-  methods: {
-   
   },
   computed: {
 
+  },
+  mounted () {
+
+  },
+  methods: {
+
   }
 }
-


### PR DESCRIPTION
* Match the recommended instance options order as laid out in 
   https://vuejs.org/v2/style-guide/index.html#Component-instance-options-order-recommended
* Add a space before parenthesis to match vue default eslint requirements