### PR TITLE
Fix windows issue with using gulp file reference

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-generate-component",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Vue js component generator",
   "main": "lib/vgc.js",
   "homepage": "https://github.com/NetanelBasal/vue-generate-component",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "lib/vgc.js",
   "homepage": "https://github.com/NetanelBasal/vue-generate-component",
   "scripts": {
-    "build": "rm -rf dist && ./node_modules/gulp/bin/gulp.js build",
+    "build": "rm -rf dist && npm run gulp -- build",
+    "gulp": "gulp",
     "prepublish": "npm run build"
   },
   "files": [


### PR DESCRIPTION
Windows apparently has an issue with trying to reference gulp through the '.' reference and wouldn't allow. This is doing the same thing it was doing before, except is just using the gulp reference from the scripts section (which is using the npm installed gulp).

Thanks for all you do!