### PR TITLE
Don't include paths in component names

### DIFF
--- a/lib/TemplateGenerator.js
+++ b/lib/TemplateGenerator.js
@@ -42,7 +42,8 @@ class TemplateGenerator {
    */
   _compileTpl( file, { name, actions, filesType } ) {
     const compiled = swig.compileFile(file);
-    return compiled({ name, actions, filesType });
+    const componentName = name.substring(name.lastIndexOf("/") + 1);
+    return compiled({ name: componentName, actions, filesType });
   }
 
   /**


### PR DESCRIPTION
When specifying a path in the filename when generating a new component (e.g. vgc src/components/test), don't include the path (src-components) in the component name within the generate files.